### PR TITLE
tag-delta: Integration with errata-tool comparing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 koji
 toolchest>=0.0.6
 koji_wrapper
+errata-tool

--- a/tag_utils/delta.py
+++ b/tag_utils/delta.py
@@ -9,8 +9,23 @@ from toolchest.rpm.utils import splitFilename
 
 from .koji import latest_tagged_as_nevr
 from .compose import compose_as_nevr
+from .et import get_build_for_release
 
 __koji_session = None
+
+
+def release_set_as_nevr(release_name_or_id, koji_session, **kwargs):
+    global __koji_session
+
+    if 'session' in kwargs:
+        __koji_session = kwargs['session']
+
+    if __koji_session is None:
+        __koji_session = KojiWrapperBase(profile='brew')
+    if __koji_session is None:
+        raise Exception('Could not connect to koji')
+
+    return get_build_for_release(release_name_or_id.strip('et:'), __koji_session)
 
 
 def tag_to_latest_builds(tag, **kwargs):
@@ -53,6 +68,8 @@ def input_to_nevr_dict(inp, **kwargs):
              inp.startswith('/')):
             # fetch compose data
             ret = compose_as_nevr(inp)
+        elif inp.startswith('et:'):
+            ret = release_set_as_nevr(inp, __koji_session, **kwargs)
         else:
             # fetch koji tag data
             ret = tag_to_latest_builds(inp, **kwargs)

--- a/tag_utils/et.py
+++ b/tag_utils/et.py
@@ -10,46 +10,53 @@ RELEASE_GROUP_SEARCH_PATH = '/api/v1/releases' + \
         '?filter[is_active]=true&filter[enabled]=true&filter[name]={}'
 ADVISORY_SEARCH_PATH = '/errata/errata_for_release/{}.json'
 
-def get_advisory_list(errata_tool_release):
-    print('Finding unshipped advisories in {}...'.format(errata_tool_release))
+def get_advisory_list(errata_tool_release, debug=False):
+    if debug:
+        print('Finding unshipped advisories in {}...'.format(errata_tool_release))
     et = ErrataConnector()
     release_group_search = et._get(
             RELEASE_GROUP_SEARCH_PATH.format(errata_tool_release))
     release_group_ids = []
     for release_group in release_group_search['data']:
         release_group_ids.append(release_group['id'])
-    print('  Potential release group IDs (using first):',
-          ' '.join(map(str, release_group_ids)))
+
+    if debug:
+        print('  Potential release group IDs (using first):',
+              ' '.join(map(str, release_group_ids)))
     advisory_search = et._get(
             ADVISORY_SEARCH_PATH.format(release_group_ids[0]))
     advisory_ids = set()
     for advisory_result in advisory_search:
         if advisory_result['status'] in ADVISORY_STATES:
             advisory_ids.add(advisory_result['id'])
-    print('  Advisories in release group {}:'.format(release_group_ids[0]),
-          ' '.join(map(str, advisory_ids)))
+    if debug:
+        print('  Advisories in release group {}:'.format(release_group_ids[0]),
+              ' '.join(map(str, advisory_ids)))
     return [Erratum(errata_id=advisory_id) for advisory_id in advisory_ids]
 
 
-def get_build_for_release(release_name_or_id, koji_session):
+def get_build_for_release(release_name_or_id, koji_session, debug=False):
     release_builds = {}
-
-    print('got in "{0}"'.format(release_name_or_id))
+    if debug:
+        print('got in "{0}"'.format(release_name_or_id))
     try:
         rel = errata_tool.release.Release(id=int(release_name_or_id))
         advisories = [i for i in rel.advisories() if i["status"] not in ('SHIPPED_LIVE', 'DROP_NO_SHIP')]
         advisory_list = [Erratum(errata_id=i['id']) for i in advisories]
-        print( ("Got list of advisories:", advisories))
+        if debug:
+            print( ("Got list of advisories:", advisories))
     except ValueError:
-        advisory_list = get_advisory_list(release_name_or_id)
+        advisory_list = get_advisory_list(release_name_or_id, debug=debug)
 
     check_list = []
     all_builds = set()
     for advisory in advisory_list:
-        print('\nFetching builds for {} "{}"'.format(
-            advisory.errata_name, advisory.synopsis))
+        if debug:
+            print('\nFetching builds for {} "{}"'.format(
+                advisory.errata_name, advisory.synopsis))
         for release, builds in advisory.errata_builds.items():
-            print('  {}: {}'.format(release, ' '.join(builds)))
+            if debug:
+                print('  {}: {}'.format(release, ' '.join(builds)))
             all_builds |= set(builds)
 
     return_data = {}

--- a/tag_utils/et.py
+++ b/tag_utils/et.py
@@ -1,0 +1,60 @@
+
+from .koji import koji_build_to_nevr
+import errata_tool.release
+from errata_tool.erratum import Erratum
+from errata_tool.connector import ErrataConnector
+
+
+ADVISORY_STATES = ('NEW_FILES', 'QE', 'REL_PREP', 'PUSH_READY')
+RELEASE_GROUP_SEARCH_PATH = '/api/v1/releases' + \
+        '?filter[is_active]=true&filter[enabled]=true&filter[name]={}'
+ADVISORY_SEARCH_PATH = '/errata/errata_for_release/{}.json'
+
+def get_advisory_list(errata_tool_release):
+    print('Finding unshipped advisories in {}...'.format(errata_tool_release))
+    et = ErrataConnector()
+    release_group_search = et._get(
+            RELEASE_GROUP_SEARCH_PATH.format(errata_tool_release))
+    release_group_ids = []
+    for release_group in release_group_search['data']:
+        release_group_ids.append(release_group['id'])
+    print('  Potential release group IDs (using first):',
+          ' '.join(map(str, release_group_ids)))
+    advisory_search = et._get(
+            ADVISORY_SEARCH_PATH.format(release_group_ids[0]))
+    advisory_ids = set()
+    for advisory_result in advisory_search:
+        if advisory_result['status'] in ADVISORY_STATES:
+            advisory_ids.add(advisory_result['id'])
+    print('  Advisories in release group {}:'.format(release_group_ids[0]),
+          ' '.join(map(str, advisory_ids)))
+    return [Erratum(errata_id=advisory_id) for advisory_id in advisory_ids]
+
+
+def get_build_for_release(release_name_or_id, koji_session):
+    release_builds = {}
+
+    print('got in "{0}"'.format(release_name_or_id))
+    try:
+        rel = errata_tool.release.Release(id=int(release_name_or_id))
+        advisories = [i for i in rel.advisories() if i["status"] not in ('SHIPPED_LIVE', 'DROP_NO_SHIP')]
+        advisory_list = [Erratum(errata_id=i['id']) for i in advisories]
+        print( ("Got list of advisories:", advisories))
+    except ValueError:
+        advisory_list = get_advisory_list(release_name_or_id)
+
+    check_list = []
+    all_builds = set()
+    for advisory in advisory_list:
+        print('\nFetching builds for {} "{}"'.format(
+            advisory.errata_name, advisory.synopsis))
+        for release, builds in advisory.errata_builds.items():
+            print('  {}: {}'.format(release, ' '.join(builds)))
+            all_builds |= set(builds)
+
+    return_data = {}
+    for build in all_builds:
+        build_data = koji_session.build(build)
+        return_data[build_data['name']] = koji_build_to_nevr(build_data)
+
+    return return_data


### PR DESCRIPTION
- added in et file which has the Errata tool specifics
- added in hook for et:XXX for tag-delta to compare from
- added get_advisory_list helper function from rcm-tools-jenkins implementation
- based on code by Andrew Hills <ahills@redhat.com>

This is to make comparing what was in an advisory to what is in
a tag in brew easier.

tag-delta et:<errata_id> <brew_tag>
tag-delta "et:<ET release name>" <brew_tag>