### PR TITLE
Fix install requirements for PyPI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.0.5 (2019-12-18)
+------------------
+* Fix install requirements for PyPI
+  
 0.0.4 (2019-12-03)
 ------------------
 * Support separate destination tag

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+
+# added by check_manifest.py
+include *.rst
+include *.txt
+include tox.ini
+recursive-include tests *.py

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: tag_utils
-Version: 0.0.4
+Version: 0.0.5
 Summary: Pungi/Koji tag utilities for Release Depot
 Author: release-depot
 Author-email: lon@metamorphism.com

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ TEST_REQUIRES = ['coverage', 'flake8', 'pytest', 'pytest-datadir', 'tox']
 
 setup(
     name='tag_utils',
-    version='0.0.4',
+    version='0.0.5',
     setup_requires=['pytest-runner'],
     install_requires=['pyyaml', 'koji', 'toolchest>=0.0.6', 'koji_wrapper'],
     tests_require=TEST_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     name='tag_utils',
     version='0.0.4',
     setup_requires=['pytest-runner'],
-    install_requires=['pyyaml'],
+    install_requires=['pyyaml', 'koji', 'toolchest>=0.0.6', 'koji_wrapper'],
     tests_require=TEST_REQUIRES,
     extras_require={'test': TEST_REQUIRES},
     license='MIT',


### PR DESCRIPTION
Some requirements were in requirements.txt but not in setup.py's install_requires. Doing 'pip install tag-utils' only looks at the latter, forcing users to manually install them.

This fixes that.