### PR TITLE
Tag-over deduplication & release 0.0.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+0.0.7 (2020-03-19)
+------------------
+* Optimize to avoid double-tagging in tag-over
+
 0.0.6 (2020-01-22)
 ------------------
 * Add Errata support

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: tag_utils
-Version: 0.0.6
+Version: 0.0.7
 Summary: Pungi/Koji tag utilities for Release Depot
 Author: release-depot
 Author-email: lon@metamorphism.com

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ TEST_REQUIRES = ['coverage', 'flake8', 'pytest', 'pytest-datadir', 'tox']
 
 setup(
     name='tag_utils',
-    version='0.0.6',
+    version='0.0.7',
     setup_requires=['pytest-runner'],
     install_requires=['pyyaml', 'koji', 'toolchest>=0.0.6', 'koji_wrapper'],
     tests_require=TEST_REQUIRES,


### PR DESCRIPTION
This adds a commit which ignores packages already tagged in the target Brew / Koji tag when running tag-over with a different destination tag.