### PR TITLE
Add mergify like we use in our other projects.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+- actions:
+    merge:
+      method: rebase
+      rebase_fallback: merge
+      strict: true
+  conditions:
+  - label!=WIP
+  - '#approved-reviews-by>=1'
+  - status-success=continuous-integration/travis-ci/pr
+  name: default


### PR DESCRIPTION
We will switch from travis to github actions as a separate
step, so having mergify look at travis job for now.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>