### PR TITLE
Update mergify config to use queue instead of merge.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,22 @@ jobs:
             pip install tox tox-gh-actions
         - name: Run Tox
           # Run tox using the version of Python in `PATH`
+          run: tox -epy
+    flake8:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Setup Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.9
+        - name: Setup System Dependencies
           run: |
-            tox
-        - name: Run Flake8
-          run: tox -e flake8
+            sudo apt update
+            sudo apt install libkrb5-dev -y
+        - name: Install Tox and any other packages
+          run: |
+            python -m pip install --upgrade pip
+            pip install tox tox-gh-actions
+        - name: Lint with flake8
+          run: tox -eflake8

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,14 +1,30 @@
+---
+
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - check-success=flake8
+      - check-success=test (3.6)
+      - check-success=test (3.7)
+      - check-success=test (3.8)
+      - check-success=test (3.9)
+
 pull_request_rules:
-- actions:
-    merge:
-      method: rebase
-      rebase_fallback: merge
-      strict: true
-  conditions:
-  - label!=WIP
-  - '#approved-reviews-by>=1'
-  - check-success=test (3.6)
-  - check-success=test (3.7)
-  - check-success=test (3.8)
-  - check-success=test (3.9)
-  name: default
+  - name: automatic merge
+    conditions:
+      - label!=WIP
+      - '#approved-reviews-by>=2'
+      # We have to duplicate these because mergify won't allow us to use an
+      # anchor
+      - check-success=flake8
+      - check-success=test (3.6)
+      - check-success=test (3.7)
+      - check-success=test (3.8)
+      - check-success=test (3.9)
+    actions:
+      queue:
+        method: rebase
+        rebase_fallback: merge
+        update_method: rebase
+        name: default


### PR DESCRIPTION
The old way of configuring merges has been deprecated since June
2021[1], so we need to move to the newer syntax.

[1] https://blog.mergify.com/strict-mode-deprecation/

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>