### PR TITLE
Allow to pass the "verify" parameter down to requests

### DIFF
--- a/tag_utils/compose.py
+++ b/tag_utils/compose.py
@@ -9,9 +9,9 @@ from toolchest.rpm.utils import componentize
 from .common import tidy_nevra
 
 
-def check_compose(url):
+def check_compose(url, verify=True):
     full_url = os.path.join(url, 'STATUS')
-    ret = requests.get(full_url)
+    ret = requests.get(full_url, verify=verify)
     if ret.status_code == 200:
         if ret.text.startswith('FINISHED'):
             return True
@@ -19,10 +19,10 @@ def check_compose(url):
     raise ValueError('Failed to check compose; HTTP code ' + str(ret.status_code))
 
 
-def fetch_rpm_metadata(url):
+def fetch_rpm_metadata(url, verify=True):
     check_compose(url)
     full_url = os.path.join(url, 'compose/metadata/rpms.json')
-    ret = requests.get(full_url)
+    ret = requests.get(full_url, verify=verify)
     if ret.status_code == 200:
         return json.loads(ret.text)
 


### PR DESCRIPTION
python-requests doesn't use the standard CA bundle from the OS, but a custom one, provided by certifi[1]. This one is, mostly, a copy of Mozilla curated bundle.

This leads to issue when you want to call the compose.py methods against an HTTPS server using custom CA.

This patch just adds the new parameter to the affected methods, setting it to "True" to keep it consistent with the default behavior. It can then be tweaked to whatever value you want from within 3rd party scripts/apps.