### PR TITLE
Update deprecated action versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
         matrix:
           python: ['3.7', '3.8', '3.9', '3.10', '3.11']
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
             python-version: ${{ matrix.python }}
         - name: Setup System Dependencies
@@ -29,9 +29,9 @@ jobs:
     flake8:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
             python-version: 3.11
         - name: Setup System Dependencies


### PR DESCRIPTION
Github has moved workers to a new node [1], so we need to update those actions before the old node is decommissioned.

[1] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/